### PR TITLE
Add support for multiple platforms in Flutter CI (#9)

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -92,7 +92,6 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: 'beta'
       
       - name: Install dependencies

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -95,9 +95,6 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: 'beta'
       
-      - name: Setup MSVC Build Tools
-        uses: microsoft/setup-msvc-build-tools@v1.0.1
-      
       - name: Install dependencies
         run: flutter pub get
 

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -5,9 +5,12 @@ on:
     branches: [ "feature/*" ]
   pull_request:
     branches: [ "develop", "main", "feature/*" ]
+    
+env:
+  FLUTTER_VERSION: "3.10.0"
 
 jobs:
-  build:
+  build-android:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -16,7 +19,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.10.0'
+          flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: 'stable'
 
       - name: Install dependencies
@@ -28,5 +31,128 @@ jobs:
       - name: Build APK
         run: flutter build apk
         
+      - name: Run tests 
+        run: flutter test --coverage
+        
+  build-ios:
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Static analysis
+        run: flutter analyze
+
+      - name: Build ios App
+        run: flutter build ios
+        
+      - name: Run tests 
+        run: flutter test --coverage
+        
+  build-web:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Static analysis
+        run: flutter analyze
+
+      - name: Build web app
+        run: flutter build web
+      
+      - name: Run tests 
+        run: flutter test --coverage    
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: 'stable'
+      
+      - name: Setup MSVC Build Tools
+        uses: microsoft/setup-msvc-build-tools@v1.0.1
+      
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Static analysis
+        run: flutter analyze
+
+      - name: Build EXE
+        run: flutter build windows
+      
+      - name: Run tests 
+        run: flutter test --coverage
+        
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Static analysis
+        run: flutter analyze
+
+      - name: Build Linux desktop application
+        run: flutter build linux
+        
+      - name: Run tests 
+        run: flutter test --coverage
+        
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Static analysis
+        run: flutter analyze
+
+      - name: Build DMG
+        run: flutter build macos
+      
       - name: Run tests 
         run: flutter test --coverage

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: 'stable'
+          architecture: x64  
 
       - name: Install dependencies
         run: flutter pub get
@@ -53,7 +54,7 @@ jobs:
         run: flutter analyze
 
       - name: Build ios App
-        run: flutter build ios
+        run: flutter build ios --release --no-codesign
         
       - name: Run tests 
         run: flutter test --coverage
@@ -92,7 +93,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: 'stable'
+          channel: 'beta'
       
       - name: Setup MSVC Build Tools
         uses: microsoft/setup-msvc-build-tools@v1.0.1
@@ -102,6 +103,9 @@ jobs:
 
       - name: Static analysis
         run: flutter analyze
+        
+      - name: Flutter config for windows
+        run: flutter config --enable-windows-desktop
 
       - name: Build EXE
         run: flutter build windows
@@ -126,7 +130,14 @@ jobs:
 
       - name: Static analysis
         run: flutter analyze
-
+        
+      - run: |
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build libgtk-3-dev
+          
+      - name: Flutter configs for linux
+        run: flutter config --enable-linux-desktop     
+      
       - name: Build Linux desktop application
         run: flutter build linux
         


### PR DESCRIPTION
This PR adds support for building Flutter applications for multiple platforms in our continuous integration (CI) workflow. The CI workflow previously only supported building Android APKs, but now supports building applications for iOS, Linux, Windows, and the web.

Fixes #9 